### PR TITLE
Change deprecated dependency importing methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,6 @@ include ':KeepScreenOn'
 project(':KeepScreenOn').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-keep-screen-on/android')
 ```
 
-#### In `build.gradle` add the following line:
-
-```groovy
-compile project(':KeepScreenOn')
-```
-
 #### < [0.29] : In `MainActivity.java` add the following lines:
 
 ```java

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,5 +27,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Android no more use compile in build.gradle after gradle plugin version 5.0.
They highly recommend to use "implementation" rather than "compile".
I was using the module you made well, but I had to keep looking at the warning whenever I built the project.
And remove compile part of your README.md documentation which no more use.

I will be glad if you approve this PR.